### PR TITLE
Improve Sign in and Sign up style

### DIFF
--- a/app/(auth-pages)/sign-in/page.tsx
+++ b/app/(auth-pages)/sign-in/page.tsx
@@ -8,7 +8,8 @@ import Link from "next/link";
 export default async function Login(props: { searchParams: Promise<Message> }) {
   const searchParams = await props.searchParams;
   return (
-    <form className="flex-1 flex flex-col min-w-64">
+    <form className="flex flex-col min-w-64 max-w-96 mx-auto">
+      <FormMessage message={searchParams} />
       <h1 className="text-2xl font-medium">Sign in</h1>
       <p className="text-sm text-foreground">
         Don't have an account?{" "}
@@ -37,7 +38,6 @@ export default async function Login(props: { searchParams: Promise<Message> }) {
         <SubmitButton pendingText="Signing In..." formAction={signInAction}>
           Sign in
         </SubmitButton>
-        <FormMessage message={searchParams} />
       </div>
     </form>
   );

--- a/app/(auth-pages)/sign-up/page.tsx
+++ b/app/(auth-pages)/sign-up/page.tsx
@@ -10,17 +10,11 @@ export default async function Signup(props: {
   searchParams: Promise<Message>;
 }) {
   const searchParams = await props.searchParams;
-  if ("message" in searchParams) {
-    return (
-      <div className="w-full flex-1 flex items-center h-screen sm:max-w-md justify-center gap-2 p-4">
-        <FormMessage message={searchParams} />
-      </div>
-    );
-  }
 
   return (
     <>
-      <form className="flex flex-col min-w-64 max-w-64 mx-auto">
+      <form className="flex flex-col min-w-64 max-w-96 mx-auto">
+        <FormMessage message={searchParams} />
         <h1 className="text-2xl font-medium">Sign up</h1>
         <p className="text-sm text text-foreground">
           Already have an account?{" "}
@@ -42,7 +36,6 @@ export default async function Signup(props: {
           <SubmitButton formAction={signUpAction} pendingText="Signing up...">
             Sign up
           </SubmitButton>
-          <FormMessage message={searchParams} />
         </div>
       </form>
       <SmtpMessage />

--- a/src/components/form-message.tsx
+++ b/src/components/form-message.tsx
@@ -4,20 +4,23 @@ export type Message =
   | { message: string };
 
 export function FormMessage({ message }: { message: Message }) {
+  const baseStyle = 'text-foreground border-l-2 border-foreground p-4 rounded-sm mb-4';
   return (
     <div className="flex flex-col gap-2 w-full max-w-md text-sm">
       {"success" in message && (
-        <div className="text-foreground border-l-2 border-foreground px-4">
+        <div className={`${baseStyle} border-green-600 bg-green-200`}>
           {message.success}
         </div>
       )}
       {"error" in message && (
-        <div className="text-destructive-foreground border-l-2 border-destructive-foreground px-4">
+        <div className={`${baseStyle} border-red-600 bg-red-200`}>
           {message.error}
         </div>
       )}
       {"message" in message && (
-        <div className="text-foreground border-l-2 px-4">{message.message}</div>
+        <div className={`${baseStyle} border-blue-600 bg-blue-200`}>
+          {message.message}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
Small changes to show a better feedback message to the user when they try to login or sign up. Based on its type, either success, error or message we show a different coloured div on top instead of below the form:

<img width="637" alt="Screenshot 2024-11-03 at 15 06 59" src="https://github.com/user-attachments/assets/0fdb5aaa-aad3-4d64-8b4d-27a8ef998207">
